### PR TITLE
[Fix] Free msg in single_send for each successful delivery

### DIFF
--- a/project-2_15-441/src/backend.c
+++ b/project-2_15-441/src/backend.c
@@ -210,6 +210,7 @@ void single_send(cmu_socket_t *sock, uint8_t *data, int buf_len) {
           break;
         }
       }
+      free(msg);
 
       data_offset += payload_len;
     }


### PR DESCRIPTION
@isuizo  This is a simple memory leak issue appeared inside backend.c. For single_send, the original version does not free memory allocated for packet created on `msg` after it is sent out successfully.


Original valgrind report
```shell
==41661== HEAP SUMMARY:
==41661==     in use at exit: 103 bytes in 2 blocks
==41661==   total heap usage: 5,625 allocs, 5,623 frees, 599,565 bytes allocated
==41661== 
==41661== 103 bytes in 2 blocks are definitely lost in loss record 1 of 1
==41661==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==41661==    by 0x109EDC: create_packet (cmu_packet.c:140)
==41661==    by 0x10B278: single_send (backend.c:382)
==41661==    by 0x10B5EC: begin_backend (backend.c:491)
==41661==    by 0x48F5AC2: start_thread (pthread_create.c:442)
==41661==    by 0x4986A73: clone (clone.S:100)
==41661== 
==41661== LEAK SUMMARY:
==41661==    definitely lost: 103 bytes in 2 blocks
==41661==    indirectly lost: 0 bytes in 0 blocks
==41661==      possibly lost: 0 bytes in 0 blocks
==41661==    still reachable: 0 bytes in 0 blocks
==41661==         suppressed: 0 bytes in 0 blocks
==41661== 
==41661== For lists of detected and suppressed errors, rerun with: -s
==41661== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
Fixed version:
```shell
==41663== HEAP SUMMARY:
==41663==     in use at exit: 0 bytes in 0 blocks
==41663==   total heap usage: 4,649 allocs, 4,649 frees, 565,808 bytes allocated
==41663== 
==41663== All heap blocks were freed -- no leaks are possible
==41663== 
==41663== For lists of detected and suppressed errors, rerun with: -s
==41663== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

